### PR TITLE
Fix missing semi-colon in example Migrations.sol

### DIFF
--- a/_site/public/docs/getting_started/migrations.md
+++ b/_site/public/docs/getting_started/migrations.md
@@ -45,7 +45,7 @@ contract Migrations {
   uint public last_completed_migration;
 
   modifier restricted() {
-    if (msg.sender == owner) _
+    if (msg.sender == owner) _;
   }
 
   function Migrations() {


### PR DESCRIPTION
Example won't compile. This is only a documentation problem, truffle init creates the proper Migrations.sol