### PR TITLE
change tests to test.

### DIFF
--- a/_site/public/docs/getting_started/testing.md
+++ b/_site/public/docs/getting_started/testing.md
@@ -9,7 +9,7 @@ Both styles of tests have their advantages and drawbacks. See the next two secti
 
 # Location
 
-All test files should be located in the `./tests` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`, and `.sol`. All other files are ignored.
+All test files should be located in the `./test` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`, and `.sol`. All other files are ignored.
 
 # Command
 


### PR DESCRIPTION
it seems the folder it looks for is test. (it is inconsistent with the other folders, contracts and migrations)

Error I get when the folder is called tests:
/usr/lib/node_modules/truffle/lib/commands/test.js:37
      files = files.filter(function(file) {
                   ^

TypeError: Cannot read property 'filter' of undefined
    at /usr/lib/node_modules/truffle/lib/commands/test.js:37:20
    at /usr/lib/node_modules/truffle/node_modules/node-dir/lib/paths.js:72:25
    at FSReqWrap.oncomplete (fs.js:123:15)