### PR TITLE
Docs > Improvement > Add previous/next navigation links

### DIFF
--- a/_site/public/docs/advanced/build_processes.md
+++ b/_site/public/docs/advanced/build_processes.md
@@ -84,3 +84,7 @@ MyContract.deployed().then(function(deployed) {
 ```
 
 All build processes and contract bootstrapping will follow this pattern. The key when setting up your own custom build process is to ensure you're consuming all of your contract artifacts and provisioning your abstractions correctly.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Networks & App Deployment](/docs/advanced/networks) || [Next: Command Reference](/docs/advanced/commands) &rarr;

--- a/_site/public/docs/advanced/commands.md
+++ b/_site/public/docs/advanced/commands.md
@@ -182,3 +182,7 @@ Watch for changes to contracts, app and configuration files. When there's a chan
 ```none
 $ truffle watch
 ```
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Build Process](/docs/advanced/build_processes)

--- a/_site/public/docs/advanced/configuration.md
+++ b/_site/public/docs/advanced/configuration.md
@@ -154,3 +154,7 @@ Example:
 ```javascript
 license: "MIT",
 ```
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Contact the developers](/docs/getting_started/contact) || [Next: Networks & App Deployment](/docs/advanced/networks) &rarr;

--- a/_site/public/docs/advanced/networks.md
+++ b/_site/public/docs/advanced/networks.md
@@ -25,3 +25,7 @@ As mentioned in the [Compiling contracts](/docs/getting_started/compile) section
 # Application Deployment
 
 Because the network is auto-detected by the contract artifacts at runtime, this means that you only need to deploy your application or frontend *once*. When your application is run, the running Ethereum client will determine which artifacts are used, and this will make your application very flexible. As an example, if you were to deploy a web application to http://mydapp.io, you could navigate to that address using your favorite wallet-browser (like MetaMask, or Mist) and your dapp would work correctly regardless of the Ethereum network the wallet-browser was connected to. If the wallet-browser was connected to the live network, your dapp would use the contracts you deployed on the live network. If on Ropsten, the contracts you deployed to Ropsten would be used.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Configuration](/docs/advanced/configuration) || [Next: Build Processes](/docs/advanced/build_processes) &rarr;

--- a/_site/public/docs/getting_started/build.md
+++ b/_site/public/docs/getting_started/build.md
@@ -14,6 +14,10 @@ $ truffle build
 
 Note you'll receive an error if you try to run the `build` command without first configuring a custom build process.
 
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Writing external scripts](/docs/getting_started/scripts) || [Next: Contact the developers](/docs/getting_started/contact) &rarr;
+
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_site/public/docs/getting_started/client.md
+++ b/_site/public/docs/getting_started/client.md
@@ -17,3 +17,7 @@ There are many official and unofficial Ethereum clients available for you to use
 # When Deploying to Private Networks
 
 Private networks utilize the same technology but with a different configuration. So you can configure any of the Ethereum clients mentioned above to run a private network, and deploy to it in exactly the same way.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Installation](/docs/getting_started/installation) || [Next: Creating a project](/docs/getting_started/project) &rarr;

--- a/_site/public/docs/getting_started/compile.md
+++ b/_site/public/docs/getting_started/compile.md
@@ -41,3 +41,7 @@ You can also use the `import` statement to import dependencies installed via pac
 # Artifacts
 
 Artifacts of your compilation will be placed in the `./build/contracts` directory, relative to your project. This directory will be created if it does not exist. These artifacts are integral to the inner workings of Truffle, and they play and important part to the successful deployment of your application. You should not edit these files by hand as they'll be overwritten by contract compilation and deployment.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Creating a project](/docs/getting_started/project) || [Next: Running migrations](/docs/getting_started/migrations) &rarr;

--- a/_site/public/docs/getting_started/console.md
+++ b/_site/public/docs/getting_started/console.md
@@ -34,3 +34,7 @@ The console provides all the features available in the Truffle command line tool
 truffle(default)> MyContract.at("0xabcd...").getValue.call(); 
 5
 ```
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Package management with NPM](/docs/getting_started/packages-npm) || [Next: Writing external scripts](/docs/getting_started/scripts) &rarr;

--- a/_site/public/docs/getting_started/contact.md
+++ b/_site/public/docs/getting_started/contact.md
@@ -10,7 +10,7 @@ The best way to contact us is through Gitter. This allows you to ask questions t
 
 ### Mailing List
 
-Subsribe to our Truffle Users Mailing list for access to news, beta releases and new features!
+Subscribe to our Truffle Users Mailing list for access to news, beta releases and new features!
 
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/slim-10_7.css" rel="stylesheet" type="text/css">
@@ -33,3 +33,5 @@ Subsribe to our Truffle Users Mailing list for access to news, beta releases and
 <!--End mc_embed_signup-->
 
 --------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Using the build pipeline](/docs/getting_started/build) || [Next: Configuration](/docs/advanced/configuration) &rarr;

--- a/_site/public/docs/getting_started/contracts.md
+++ b/_site/public/docs/getting_started/contracts.md
@@ -212,3 +212,7 @@ var instance = MetaCoin.at("0x1234...");
 # Further Reading
 
 The contract abstractions provided by Truffle contain a wealth of utilities for making interacting with your contracts easy. Check out the [truffle-contract](https://github.com/trufflesuite/truffle-contract) documentation for tips, tricks and insights.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Writing tests in Solidity](/docs/getting_started/solidity-tests) || [Next: Package management via EthPM](/docs/getting_started/packages-ethpm) &rarr;

--- a/_site/public/docs/getting_started/installation.md
+++ b/_site/public/docs/getting_started/installation.md
@@ -17,3 +17,6 @@ If you're a Windows user, we recommend installing and using Truffle via Windows 
 
 If you must use the Command Prompt, please see [this discussion](/advanced/configuration/#resolving-naming-conflicts-on-windows) about configuring Truffle.
 
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Introduction](/docs/) || [Next: Choosing an Ethereum client](/docs/getting_started/client) &rarr;

--- a/_site/public/docs/getting_started/javascript-tests.md
+++ b/_site/public/docs/getting_started/javascript-tests.md
@@ -90,3 +90,7 @@ Using network 'development'.
 # Advanced
 
 Truffle gives you access to Mocha's configuration so you can change how Mocha behaves. See the [project configuration](/docs/advanced/configuration/#mocha) section for more details.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Testing your contracts](/docs/getting_started/testing) || [Next: Writing tests in Solidity](/docs/getting_started/solidity-tests) &rarr;

--- a/_site/public/docs/getting_started/migrations.md
+++ b/_site/public/docs/getting_started/migrations.md
@@ -195,3 +195,7 @@ deployer.then(function() {
   return b.setA(a.address);
 });
 ```
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Compiling contracts](/docs/getting_started/compile) || [Next: Testing your contracts](/docs/getting_started/testing) &rarr;

--- a/_site/public/docs/getting_started/packages-ethpm.md
+++ b/_site/public/docs/getting_started/packages-ethpm.md
@@ -155,3 +155,7 @@ $ truffle networks --clean
 ```
 
 See the [command reference](/docs/advanced/commands#networks) for more information.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Interacting with your contracts](/docs/getting_started/contracts) || [Next: Package management via NPM](/docs/getting_started/packages-npm) &rarr;

--- a/_site/public/docs/getting_started/packages-npm.md
+++ b/_site/public/docs/getting_started/packages-npm.md
@@ -108,6 +108,10 @@ $ truffle networks --clean
 
 See the [command reference](/docs/advanced/commands#networks) for more information.
 
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Package management with EthPM](/docs/getting_started/packages-ethpm) || [Next: Using the console](/docs/getting_started/console) &rarr;
+
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/_site/public/docs/getting_started/project.md
+++ b/_site/public/docs/getting_started/project.md
@@ -25,3 +25,7 @@ Once completed, you'll now have a project structure with the following items:
 # Default Contracts: MetaCoin
 
 By default, `truffle init` gives you a set of example contracts (`MetaCoin` and `ConvertLib`) which act like a simple alt-coin built on top of Ethereum. You can use these contracts to learn quickly while navigating through the Getting Started guide, or delete these files and build a project of your own.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Choosing an Ethereum client](/docs/getting_started/client) || [Next: Compiling contracts](/docs/getting_started/compile) &rarr;

--- a/_site/public/docs/getting_started/scripts.md
+++ b/_site/public/docs/getting_started/scripts.md
@@ -22,3 +22,6 @@ module.exports = function(callback) {
 
 You can do anything you'd like within this script, so long as the callback is called when the script finishes. The callback accepts an error as its first and only parameter. If an error is provided, execution will halt and the process will return a non-zero exit code.
 
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Using the console](/docs/getting_started/console) || [Next: Using the build pipeline](/docs/getting_started/build) &rarr;

--- a/_site/public/docs/getting_started/solidity-tests.md
+++ b/_site/public/docs/getting_started/solidity-tests.md
@@ -145,3 +145,7 @@ contract TestContract {
 ```
 
 Note that Truffle sends Ether to your test contract in a way that does **not** execute a fallback function, so you can still use the fallback function within your Solidity tests for advanced test cases.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Writing tests in Javascript](/docs/getting_started/javascript-tests) || [Next: Interacting with your contracts](/docs/getting_started/contracts) &rarr;

--- a/_site/public/docs/getting_started/testing.md
+++ b/_site/public/docs/getting_started/testing.md
@@ -32,3 +32,7 @@ Truffle provides a clean room environment when running your test files. When run
 # Speed & Reliability Considerations
 
 The [EthereumJS TestRPC](https://github.com/ethereumjs/testrpc) is significantly faster than other clients when running automated tests. Moreover, the TestRPC contains special features which Truffle takes advantage of to speed up test runtime by almost 90%. As a general workflow, we recommend you use the TestRPC during normal development and testing, and then run your tests once against go-ethereum or another official Ethereum client when you're gearing up to deploy to live or production networks.
+
+-------------------------------
+<!-- previous/next page links -->
+&larr; [Previous: Running migrations](/docs/getting_started/migrations) || [Next: Writing tests in Javascript](/docs/getting_started/javascript-tests) &rarr;

--- a/_site/public/docs/index.md
+++ b/_site/public/docs/index.md
@@ -41,7 +41,8 @@ Subscribe to our mailing list for news, beta releases and new features!
 <!--End mc_embed_signup-->
 
 -------------------------------
-
+<!-- previous/next page links -->
+&larr; [Previous: Home](http://truffleframework.com/) || [Next: Installation](/docs/getting_started/installation) &rarr;
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Add previous/next navigation links to all docs pages in Getting Started and Advanced sections.

Also includes a typo fix for the word 'Subscribe' (missing letter) on the docs/getting_started/contact.md page.