### PR TITLE
Remove localhost:9000 reference.

### DIFF
--- a/_site/public/docs/advanced/configuration.md
+++ b/_site/public/docs/advanced/configuration.md
@@ -26,7 +26,7 @@ The default configuration ships with configuration for a single development netw
 
 ### build
 
-Build configuration of your application, if your application requires tight integration with Truffle. Most users likely will not need to configure this option. See the [Advanced Build Processes](http://localhost:9000/docs/advanced/build_processes) section for more details.
+Build configuration of your application, if your application requires tight integration with Truffle. Most users likely will not need to configure this option. See the [Advanced Build Processes](/docs/advanced/build_processes) section for more details.
 
 ### networks
 


### PR DESCRIPTION
Fixed link to Advanced Build Processes by removing the reference to localhost.