### PR TITLE
Correct typo in test folder name

### DIFF
--- a/_site/public/docs/getting_started/testing.md
+++ b/_site/public/docs/getting_started/testing.md
@@ -9,7 +9,7 @@ Both styles of tests have their advantages and drawbacks. See the next two secti
 
 # Location
 
-All test files should be located in the `./tests` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`, and `.sol`. All other files are ignored.
+All test files should be located in the `./test` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`, and `.sol`. All other files are ignored.
 
 # Command
 


### PR DESCRIPTION
The command

```
$ truffle test
```

uses the ./test folder, not ./tests folder