### PR TITLE
Fix typo in getting_started/project.md

### DIFF
--- a/_site/public/docs/getting_started/project.md
+++ b/_site/public/docs/getting_started/project.md
@@ -28,7 +28,7 @@ By default, `truffle init` gives you a set of example contracts (`MetaCoin` and 
 
 # Advanced Initialization
 
-By default, `truffle init` creates a simple project for you so you can get familiar with writing, compiling and deploying Solidity-based smart contracts. However, if you'd like to tag a stab at building an Ethereum-based web application, we recommend using the following command instead:
+By default, `truffle init` creates a simple project for you so you can get familiar with writing, compiling and deploying Solidity-based smart contracts. However, if you'd like to take a stab at building an Ethereum-based web application, we recommend using the following command instead:
 
 ```
 $ truffle init webpack


### PR DESCRIPTION
"tag a stab" -> "take a stab"