### PR TITLE
Fix comment - code discrepancy

### DIFF
--- a/_site/public/docs/getting_started/migrations.md
+++ b/_site/public/docs/getting_started/migrations.md
@@ -135,7 +135,7 @@ To conditionally stage deployment steps, write your migrations so that they acce
 
 ```javascript
 module.exports = function(deployer, network) {
-  if (network != "live") {
+  if (network == "live") {
     // Do something specific to the network named "live".
   } else {
     // Perform a different step otherwise.


### PR DESCRIPTION
The comment states 
> Do something specific to the network name "live"  

However, the code the comment belongs to only gets executed if the network is **not** named "live"