### PR TITLE
Update project.md to `truffle unbox` to avoid deprecation warning

### DIFF
--- a/_site/public/docs/getting_started/project.md
+++ b/_site/public/docs/getting_started/project.md
@@ -31,7 +31,7 @@ By default, `truffle init` gives you a set of example contracts (`MetaCoin` and 
 By default, `truffle init` creates a simple project for you so you can get familiar with writing, compiling and deploying Solidity-based smart contracts. However, if you'd like to tag a stab at building an Ethereum-based web application, we recommend using the following command instead:
 
 ```
-$ truffle init webpack
+$ truffle unbox
 ```
 
 This will download and install a copy of [this project](https://github.com/trufflesuite/truffle-init-webpack) that integrates both Truffle and Webpack, giving you the power of Webpack for web development and Truffle for Ethereum development.


### PR DESCRIPTION
Running`truffle init webpack` is now deprecated. Update to docs avoids users encountering warning:
`Using `truffle init` with a specific template is deprecated. Please use `truffle unbox` instead.`