### PR TITLE
fix its

### DIFF
--- a/_site/public/docs/getting_started/contracts.md
+++ b/_site/public/docs/getting_started/contracts.md
@@ -28,7 +28,7 @@ Choosing between a transaction and a call is as simple as deciding whether you w
 
 # Introducing Abstractions
 
-Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle-contract) module, and its this contract abstraction that's described below.
+Contract abstractions are the bread and butter of interacting with Ethereum contracts from Javascript. In short, contract abstractions are wrapper code that makes interaction with your contracts easy, in a way that lets you forget about the many engines and gears executing under the hood. Truffle uses its own contract abstraction via the [truffle-contract](https://github.com/trufflesuite/truffle-contract) module, and it is this contract abstraction that's described below.
 
 In order to appreciate the usefulness of a contract abstraction, however, we first need a contract to talk about. We'll use the MetaCoin contract provided for you by default via `truffle init`.
 


### PR DESCRIPTION
Small English fix.
Small things are important.
Please accept this humble request, to allow this small thing to be right.
This is an "it is" so it should not be "its" but "it's". However, "It is" is clearest, so "it is" it is. :)