### PR TITLE
Wrong file name in Compilation

### DIFF
--- a/_site/public/tutorials/pet-shop.md
+++ b/_site/public/tutorials/pet-shop.md
@@ -138,8 +138,8 @@ Open a new console window and run the command `testrpc`. This starts a new, loca
 Back in your first console window, run the command `truffle compile`. You should see the following output:
 
 ```shell
+Compiling ./contracts/Adoption.sol...
 Compiling ./contracts/Migrations.sol...
-Compiling ./contracts/PetShop.sol...
 Writing artifacts to ./build/contracts
 ```
 


### PR DESCRIPTION
In the section, 'Compilation',

File name should be `Adoption.sol`.

There is no file like `PetShop.sol` in the example.