### PR TITLE
Added pragma statement in the test code

### DIFF
--- a/_site/public/tutorials/pet-shop.md
+++ b/_site/public/tutorials/pet-shop.md
@@ -191,6 +191,8 @@ Truffle is very flexible when it comes to smart contract testing. Tests can be w
 Begin by creating the smart contract TestAdoption.sol in the test directory with the following contents:
 
 ```javascript
+pragma solidity ^0.4.11;
+
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
 import "../contracts/Adoption.sol";


### PR DESCRIPTION
If the `pragma` statement is not added, the test code produces a warning like below:

```
/C/gitrepo/pet-shop-tutorial/test/TestAdoption.sol:1:1: : Source file does not specify required compiler version!Consider adding "pragma solidity ^0.4.11
import "truffle/Assert.sol";
^
```