### PR TITLE
Fix copy/paste error in tutorial instructions

### DIFF
--- a/_site/public/tutorials/pet-shop.md
+++ b/_site/public/tutorials/pet-shop.md
@@ -319,7 +319,7 @@ If no injected web3 instance is present, we create our web3 object based on the 
 
 Now that we can interact with Ethereum via web3, we need to instantiate our smart contract so web3 knows where to find it and how it works. Truffle has a library to help with this called `truffle-contract`. It keeps information about our contract in sync with your migrations, so you don't need to change the contract's deployed address manually.
 
-Remove the multi-line comment from initWeb3 and replace it with the following:
+Remove the multi-line comment from initContract and replace it with the following:
 
 ```javascript
 $.getJSON('Adoption.json', function(data) {


### PR DESCRIPTION
There are 2 references to replace comments in initWeb3, the second one should be initContract