### PR TITLE
1 second blocktime setting

### DIFF
--- a/_site/public/tutorials/chain-forking-exploiting-the-dao.md
+++ b/_site/public/tutorials/chain-forking-exploiting-the-dao.md
@@ -87,7 +87,12 @@ web3.currentProvider.sendAsync({
 }, callback);
 ```
 
-This will tell the TestRPC to alter its timestamp by `86400` seconds. This feature allows you to write tests that have a time component, and in our case allows us to continue executing code after a deadline is reached.
+This will tell the TestRPC to alter its timestamp by `86400` seconds. This feature allows you to write tests that have a time component, and in our case allows us to continue executing code after a deadline is reached. 
+
+Note: to make this work, you have to set the blocktime of TestRPC to 1 second, the default is zero which won't work: 
+```console
+testrpc -b 1
+```
 
 ### Step 4: Deploy our hack contract to the network
 


### PR DESCRIPTION
I think 1 second blocktime has to be specified for the "time travel" to work, and I couldn't find it mentioned anywhere