### PR TITLE
Update "using-infura-custom-provider.md" tutorial to web3 0.14.0

### DIFF
--- a/_site/public/tutorials/using-infura-custom-provider.md
+++ b/_site/public/tutorials/using-infura-custom-provider.md
@@ -25,6 +25,7 @@ var ProviderEngine = require("web3-provider-engine");
 var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
 var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
+var web3 = new Web3();
 ```
 
 These dependencies are used for the following things:
@@ -59,7 +60,7 @@ Next, we need to set up the Provider Engine, telling it that we'd like to use ou
 var providerUrl = "https://testnet.infura.io";
 var engine = new ProviderEngine();
 engine.addProvider(new WalletSubprovider(wallet, {}));
-engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(providerUrl)));
+engine.addProvider(new Web3Subprovider(new web3.providers.HttpProvider(providerUrl)));
 engine.start(); // Required by the provider engine.
 ```
 
@@ -95,6 +96,7 @@ var ProviderEngine = require("web3-provider-engine");
 var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
 var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
+var web3 = new Web3();
 
 // Get our mnemonic and create an hdwallet
 var mnemonic = "couch solve unique spirit wine fine occur rhythm foot feature glory away";
@@ -108,7 +110,7 @@ var address = "0x" + wallet.getAddress().toString("hex");
 var providerUrl = "https://testnet.infura.io";
 var engine = new ProviderEngine();
 engine.addProvider(new WalletSubprovider(wallet, {}));
-engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(providerUrl)));
+engine.addProvider(new Web3Subprovider(new web3.providers.HttpProvider(providerUrl)));
 engine.start(); // Required by the provider engine.
 
 module.exports = {


### PR DESCRIPTION
From web3.js docs:

web3.js version 0.14.0 supports multiple instances of web3 object. To migrate to this version, please follow the guide:
```
-var web3 = require('web3');
+var Web3 = require('web3');
+var web3 = new Web3();
```