### PR TITLE
Fix typo in code

### DIFF
--- a/_site/public/tutorials/pet-shop.md
+++ b/_site/public/tutorials/pet-shop.md
@@ -313,7 +313,7 @@ if (typeof web3 !== 'undefined') {
   web3 = new Web3(web3.currentProvider);
 } else {
   // set the provider you want from Web3.providers
-  App.web3Provider = new web3.providers.HttpProvider('http://localhost:8545');
+  App.web3Provider = new Web3.providers.HttpProvider('http://localhost:8545');
   web3 = new Web3(App.web3Provider);
 }
 ```


### PR DESCRIPTION
Fix a typo in the fallback mechanism of the provided code that would
prevent an user from running the Dapp on this tutorial directly from
a non Metamask-enabled browser